### PR TITLE
fix: some images come with wrong src in md

### DIFF
--- a/src/importer/PageImporter.js
+++ b/src/importer/PageImporter.js
@@ -25,6 +25,7 @@ import { md2docx } from '@adobe/helix-md2docx';
 import Utils from '../utils/Utils.js';
 import DOMUtils from '../utils/DOMUtils.js';
 import FileUtils from '../utils/FileUtils.js';
+import MDUtils from '../utils/MDUtils.js';
 
 export default class PageImporter {
   params;
@@ -143,14 +144,10 @@ export default class PageImporter {
       }
     });
 
-    const patchSrcInContent = (c, oldSrc, newSrc) => contents
-      .replace(new RegExp(`${oldSrc.replace('.', '\\.').replace('?', '\\?')}`, 'gm'), newSrc)
-      .replace(new RegExp(`${decodeURI(oldSrc).replace('.', '\\.')}`, 'gm'), newSrc);
-
     // adjust assets url (from relative to absolute)
     assets.forEach((asset) => {
       const u = new URL(decodeURI(asset.url), url);
-      contents = patchSrcInContent(contents, asset.url, u.toString());
+      contents = MDUtils.replaceSrcInMarkdown(contents, asset.url, u.toString());
     });
 
     if (resource.prepend) {

--- a/src/utils/MDUtils.js
+++ b/src/utils/MDUtils.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export default class MDUtils {
+  static replaceSrcInMarkdown = (md, oldSrc, newSrc) => {
+    if (decodeURI(oldSrc) !== oldSrc) {
+      return md.replace(new RegExp(`${decodeURI(oldSrc).replace('.', '\\.')}`, 'gm'), newSrc);
+    } else {
+      return md.replace(new RegExp(`${oldSrc.replace('.', '\\.').replace('?', '\\?')}`, 'gm'), newSrc);
+    }
+  };
+}

--- a/test/utils/MDUtils.spec.js
+++ b/test/utils/MDUtils.spec.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { strictEqual } from 'assert';
+import { describe, it } from 'mocha';
+
+import MDUtils from '../../src/utils/MDUtils.js';
+
+describe.only('MDUtils tests', () => {
+  it('MDUtils#replaceSrcInMarkdown do nothing', () => {
+    strictEqual(
+      MDUtils.replaceSrcInMarkdown('#A title\n![](https://www.sample.com/image.jpg)', 'https://www.sample.com/replace.jpg', 'https://www.sample.com/withimage.jpg'),
+      '#A title\n![](https://www.sample.com/image.jpg)',
+      'do nothing',
+    );
+  });
+
+  it('MDUtils#replaceSrcInMarkdown can replace', () => {
+    strictEqual(
+      MDUtils.replaceSrcInMarkdown('#A title\n![](https://www.sample.com/image.jpg)', 'https://www.sample.com/image.jpg', 'https://www.sample.com/withimage.jpg'),
+      '#A title\n![](https://www.sample.com/withimage.jpg)',
+      'basic replacement',
+    );
+
+    strictEqual(
+      MDUtils.replaceSrcInMarkdown('#A title\n![](/image.jpg)', '/image.jpg', 'https://www.sample.com/image.jpg'),
+      '#A title\n![](https://www.sample.com/image.jpg)',
+      'relative to absolute replacement',
+    );
+
+    strictEqual(
+      MDUtils.replaceSrcInMarkdown('![](/book/resources/_prod/img/hero/image.jpg)\n\n# Title for the page', '/book/resources/_prod/img/hero/image.jpg', 'https://www.sample.com/book/resources/_prod/img/hero/image.jpg'),
+      '![](https://www.sample.com/book/resources/_prod/img/hero/image.jpg)\n\n# Title for the page',
+      'relative to absolute replacement (no double replacement)',
+    );
+  });
+
+  it('MDUtils#replaceSrcInMarkdown can replace with encoding', () => {
+    strictEqual(
+      MDUtils.replaceSrcInMarkdown('#A title\n![](https://www.sample.com/imagé.jpg)', 'https://www.sample.com/imag%C3%A9.jpg', 'https://www.sample.com/withsomethingelse.jpg'),
+      '#A title\n![](https://www.sample.com/withsomethingelse.jpg)',
+      'encoded to replacement',
+    );
+  });
+});

--- a/test/utils/MDUtils.spec.js
+++ b/test/utils/MDUtils.spec.js
@@ -15,7 +15,7 @@ import { describe, it } from 'mocha';
 
 import MDUtils from '../../src/utils/MDUtils.js';
 
-describe.only('MDUtils tests', () => {
+describe('MDUtils tests', () => {
   it('MDUtils#replaceSrcInMarkdown do nothing', () => {
     strictEqual(
       MDUtils.replaceSrcInMarkdown('#A title\n![](https://www.sample.com/image.jpg)', 'https://www.sample.com/replace.jpg', 'https://www.sample.com/withimage.jpg'),


### PR DESCRIPTION
Images with relative src are transformed with absolute src but the conversion is broken - src looks like this:
https://www.sample.comhttps//www.sample.com/book/resources/_prod/img/hero/calgary.jpg