### PR TITLE
feat: exclude filtering if span has class or id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/helix-importer",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/utils/DOMUtils.js
+++ b/src/utils/DOMUtils.js
@@ -144,8 +144,8 @@ export default class DOMUtils {
   static removeSpans(document) {
     // remove spans
     document.querySelectorAll('span').forEach((span) => {
-      if (!span.querySelector('img')) {
-        // do not touch spans with images
+      // do not touch spans with images and span with a css class or an id
+      if (!span.querySelector('img') && span.classList.length === 0 && !span.id) {
         if (span.textContent === '') {
           span.remove();
         } else {

--- a/test/utils/DOMUtils.spec.js
+++ b/test/utils/DOMUtils.spec.js
@@ -190,6 +190,8 @@ describe('DOMUtils#removeSpans tests', () => {
     test('<p>Spacing<span> should</span> remain the <span>same even</span> with<span> multiple spans</span></p>', '<p>Spacing should remain the same even with multiple spans</p>');
     test('<span><div><img src="animage.jpg"></div></span>', '<span><div><img src="animage.jpg"></div></span>');
     test('<span>Some image here: <div><img src="animage.jpg"></div></span>', '<span>Some image here: <div><img src="animage.jpg"></div></span>');
+    test('<div>Spans potentially used to do layouting: <span class="tab1">tab1</span><span class="tab2">tab2</span></div>', '<div>Spans potentially used to do layouting: <span class="tab1">tab1</span><span class="tab2">tab2</span></div>');
+    test('<div>Spans potentially used to do layouting: <span id="tab1">tab1</span><span id="tab2">tab2</span></div>', '<div>Spans potentially used to do layouting: <span id="tab1">tab1</span><span id="tab2">tab2</span></div>');
   });
 });
 


### PR DESCRIPTION
Some spans are removed while they are useful for layout - structure is then lost and it is then impossible to extract content.