### PR TITLE
feat: import one document -> multiple output

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Idea of an explorer is to crawl the site in order to collect a list of urls. Thi
 
 Here is a basic sample:
 
-```typescript
+```js
 
 import { WPContentPager, FSHandler, CSV } from '@adobe/helix-importer';
 
@@ -42,11 +42,22 @@ The final result is a list of urls that could be found on list of paged results 
 
 ## Importer
 
-An importer must extends [PageImporter](src/importer/PageImporter.ts) and implement the `fetch` and `process` method. The general idea is that `fetch` receives the url to import and is responsible to return the HTML. `process` receives the corresponding Document in order to filter / rearrange / reshuffle the DOM before it gets processed by the Markdown transformer. `process` computes and defines the list of [PageImporterResource](src/importer/PageImporterResource.ts) (could be more than one), each resource being transformed as a Markdown document.
+An importer must extends [PageImporter](src/importer/PageImporter.js) and implement the `fetch` and `process` method. The general idea is that `fetch` receives the url to import and is responsible to return the HTML. `process` receives the corresponding Document in order to filter / rearrange / reshuffle the DOM before it gets processed by the Markdown transformer. `process` computes and defines the list of [PageImporterResource](src/importer/PageImporterResource.ts) (could be more than one), each resource being transformed as a Markdown document.
 
 Goal of the importer is to get rid of the generic DOM elements like the header / footer, the nav... and all elements that are common to all pages in order to get the unique piece(s) of content per page.
 
-You can find a large collection of importer examples in repo: https://github.com/kptdobe/helix-importer-projects
+### HTML2x helpers
+
+[HTML2x](src/importer/HTML2x.js) methods (`HTML2md` and `HTML2docx`) are convienence methods to run an import. As input, they take:
+- `URL`: URL of the page to import
+- `document`: the DOM element to import
+- `transformerCfg`: object with the transformation "rules". Object can be either:
+  - `{ transformDOM: ({ url, document, html }) => { ... return element-to-convert  }, generateDocumentPath: ({ url, document }) => { ... return path-to-target; }}` for a single mapping between one input document / one output file
+  - `{ transform: ({ url, document, html }) => { ... return [{ element: first-element-to-convert, path: first-path-to-target }, ...]  }` for a mapping one input document / multiple output files (useful to generate multiple docx from a single web page)
+
+### Importer UI
+
+The Helix Importer has a dedicated browser UI: see https://github.com/adobe/helix-importer-ui
 
 ## Installation
 
@@ -58,6 +69,6 @@ TODO: publish npm module
 
 ## Usage
 
-```typescript
+```js
 import { ... } from '@adobe/helix-importer';
 ```

--- a/src/importer/PageImporter.js
+++ b/src/importer/PageImporter.js
@@ -160,7 +160,7 @@ export default class PageImporter {
     contents = this.postProcessMD(contents);
 
     return {
-      path: `${directory}/${sanitizedName}`,
+      path: path.join(directory, sanitizedName),
       content: contents,
     };
   }
@@ -295,6 +295,8 @@ export default class PageImporter {
           const res = await this.createMarkdown(entry, url);
           // eslint-disable-next-line no-param-reassign
           entry.source = url;
+          // eslint-disable-next-line no-param-reassign
+          entry.path = res.path;
           // eslint-disable-next-line no-param-reassign
           entry.markdown = res.content;
 

--- a/test/importers/HTML2x.spec.js
+++ b/test/importers/HTML2x.spec.js
@@ -56,7 +56,7 @@ describe('html2md tests', () => {
     strictEqual(out.path, '/page');
   });
 
-  it('html2md handles a custom transformations', async () => {
+  it('html2md handles a custom transformation', async () => {
     const out = await html2md('https://www.sample.com/page.html', '<html><body><h1>Hello World</h1></body></html>', {
       transformDOM: ({ document }) => {
         const p = document.createElement('p');
@@ -68,6 +68,65 @@ describe('html2md tests', () => {
     strictEqual(out.html.trim(), '<p>My Hello to the World</p>');
     strictEqual(out.md.trim(), 'My Hello to the World');
     strictEqual(out.path, '/folder/my-custom-path');
+  });
+
+  it('html2md handles multiple transform', async () => {
+    const out = await html2md('https://www.sample.com/page.html', '<html><body><h1>Hello World</h1></body></html>', {
+      transform: ({ document }) => {
+        const p1 = document.createElement('p');
+        p1.innerHTML = 'My Hello to the World 1';
+
+        const p2 = document.createElement('p');
+        p2.innerHTML = 'My Hello to the World 2';
+
+        return [{
+          element: p1,
+          path: '/my-custom-path-p1',
+        }, {
+          element: p2,
+          path: '/folder/my-custom-path-p2',
+        }];
+      },
+    });
+
+    const out1 = out[0];
+    strictEqual(out1.html.trim(), '<p>My Hello to the World 1</p>');
+    strictEqual(out1.md.trim(), 'My Hello to the World 1');
+    strictEqual(out1.path, '/my-custom-path-p1');
+
+    const out2 = out[1];
+    strictEqual(out2.html.trim(), '<p>My Hello to the World 2</p>');
+    strictEqual(out2.md.trim(), 'My Hello to the World 2');
+    strictEqual(out2.path, '/folder/my-custom-path-p2');
+  });
+
+  it('html2md handles multiple transform', async () => {
+    const out = await html2md('https://www.sample.com/page.html', '<html><body><h1>Hello World</h1></body></html>', {
+      transform: ({ document }) => {
+        const p1 = document.createElement('p');
+        p1.innerHTML = 'My Hello to the World 1';
+
+        const p2 = document.createElement('p');
+        p2.innerHTML = 'My Hello to the World 2';
+
+        return {
+          element: p1,
+          path: '/my-custom-path-p1',
+        };
+      },
+    });
+
+    strictEqual(out.html.trim(), '<p>My Hello to the World 1</p>');
+    strictEqual(out.md.trim(), 'My Hello to the World 1');
+    strictEqual(out.path, '/my-custom-path-p1');
+  });
+
+  it('html2md does not crash if transform returns null', async () => {
+    const out = await html2md('https://www.sample.com/page.html', '<html><body><h1>Hello World</h1></body></html>', {
+      transform: () => null,
+    });
+
+    strictEqual(out.length, 0);
   });
 
   it('html2md can deal with null returning transformation', async () => {

--- a/test/importers/PageImporter.spec.js
+++ b/test/importers/PageImporter.spec.js
@@ -76,6 +76,7 @@ describe('PageImporter tests - various options', () => {
     const results = await se.import('/someurl');
 
     strictEqual(results.length, 1, 'expect no result');
+    strictEqual(results[0].path, '/someurl/somecomputedpath/resource1', 'expect no result');
 
     ok(await storageHandler.exists('/someurl/somecomputedpath/resource1.md'), 'md has been stored');
     ok(await storageHandler.exists('/someurl/somecomputedpath/resource1.docx'), 'docx has been stored');
@@ -144,7 +145,7 @@ describe('PageImporter tests - fixtures', () => {
 
     strictEqual(results.length, 1, 'expect one result');
 
-    const md = await storageHandler.get(`/${feature}.md`);
+    const md = await storageHandler.get(results[0].md);
     const expectedMD = await fs.readFile(path.resolve(__dirname, 'fixtures', `${feature}.spec.md`), 'utf-8');
     strictEqual(md.trim(), expectedMD.trim(), 'inported md is expected one');
   };


### PR DESCRIPTION
Required importer library part for https://github.com/adobe/helix-importer-ui/issues/5.

Extends the code to allow the transformer config to be either:

Single output (same as current):

```js
{ 
  transformDOM: ({ url, document, html }) => { ... return element-to-convert  },
  generateDocumentPath: ({ url, document }) => { ... return path-to-target; }
}
```

Multiple output:
```js
{ 
  transform: ({ url, document, html }) => { 
    // ...
    return [{ 
      element: first-element-to-convert,
      path: first-path-to-target
    },{ 
      element: second-element-to-convert,
      path: second-path-to-target
    }, /* ... */];
  }
}
```
