### PR TITLE
feat: preprocess transformation function - give access to the original DOM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/helix-importer",
-  "version": "2.2.1",
+  "version": "2.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/helix-importer",
-      "version": "2.2.1",
+      "version": "2.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-markdown-support": "6.0.0",

--- a/src/importer/HTML2x.js
+++ b/src/importer/HTML2x.js
@@ -21,7 +21,7 @@ import Utils from '../utils/Utils.js';
 
 // import docxStylesXML from '../resources/styles.xml';
 
-function preprocessDOM(document) {
+function setBackgroundImagesFromCSS(document) {
   const elements = document.querySelectorAll('body, header, footer, div, span, section, main');
   const getComputedStyle = document.defaultView?.getComputedStyle;
   if (getComputedStyle) {
@@ -76,8 +76,19 @@ async function html2x(
     }
   }
 
-  if (config.preprocess !== false) {
-    preprocessDOM(doc);
+  // for more advanced use cases, give access to the original dom with
+  // no preprocessing at all
+  if (transformer.preprocess) {
+    transformer.preprocess({
+      url,
+      document: doc,
+      html: doc.documentElement.outerHTML,
+      params,
+    });
+  }
+
+  if (config.setBackgroundImagesFromCSS !== false) {
+    setBackgroundImagesFromCSS(doc);
   }
 
   const html = doc.documentElement.outerHTML;


### PR DESCRIPTION
For some advanced use cases, the importer developer might need access to the original DOM, before any pre-processing (see [all processing tasks here](https://github.com/adobe/helix-importer/blob/main/src/importer/PageImporter.js#L194-L252)) in order to influence the importer preprocessing.