### PR TITLE
feat: allow to transform and report back

### DIFF
--- a/src/importer/HTML2x.js
+++ b/src/importer/HTML2x.js
@@ -116,10 +116,15 @@ async function html2x(
         results.forEach((result) => {
           const name = path.basename(result.path);
           const dirname = path.dirname(result.path);
-
-          const pir = new PageImporterResource(name, dirname, result.element, null, {
+          const extra = {
             html: result.element.outerHTML,
-          });
+          };
+
+          if (result.report) {
+            extra.report = result.report;
+          }
+
+          const pir = new PageImporterResource(name, dirname, result.element, null, extra);
           pirs.push(pir);
         });
         return pirs;
@@ -180,6 +185,10 @@ async function html2x(
     const res = {
       html: pir.extra.html,
     };
+
+    if (pir.extra.report) {
+      res.report = pir.extra.report;
+    }
 
     res.path = path.resolve(pir.directory, pir.name);
 


### PR DESCRIPTION
A frequently requested feature: allow to report some info back. 

The helix-importer-ui offers a report mechanism which provides an Excel spreadsheet will all the URLs imported and some process info. The ask to is be able to add more data per imported entry to the sheet.
