### PR TITLE
feat: allow no element

### DIFF
--- a/src/importer/HTML2x.js
+++ b/src/importer/HTML2x.js
@@ -116,9 +116,11 @@ async function html2x(
         results.forEach((result) => {
           const name = path.basename(result.path);
           const dirname = path.dirname(result.path);
-          const extra = {
-            html: result.element.outerHTML,
-          };
+          const extra = {};
+
+          if (result.element) {
+            extra.html = result.element.outerHTML;
+          }
 
           if (result.report) {
             extra.report = result.report;
@@ -182,9 +184,11 @@ async function html2x(
   const pirs = await importer.import(url);
 
   const getResponseObjectFromPIR = async (pir) => {
-    const res = {
-      html: pir.extra.html,
-    };
+    const res = {};
+
+    if (pir.extra && pir.extra.html) {
+      res.html = pir.extra.html;
+    }
 
     if (pir.extra.report) {
       res.report = pir.extra.report;
@@ -192,11 +196,11 @@ async function html2x(
 
     res.path = path.resolve(pir.directory, pir.name);
 
-    if (config.toMd) {
+    if (config.toMd && pir.md) {
       const md = await storageHandler.get(pir.md);
       res.md = md;
     }
-    if (config.toDocx) {
+    if (config.toDocx && pir.docx) {
       const docx = await storageHandler.get(pir.docx);
       res.docx = docx;
     }

--- a/src/importer/PageImporter.js
+++ b/src/importer/PageImporter.js
@@ -314,28 +314,30 @@ export default class PageImporter {
 
       if (entries) {
         await Utils.asyncForEach(entries, async (entry) => {
-          const res = await this.createMarkdown(entry, url);
-          // eslint-disable-next-line no-param-reassign
-          entry.source = url;
-          // eslint-disable-next-line no-param-reassign
-          entry.path = res.path;
-          // eslint-disable-next-line no-param-reassign
-          entry.markdown = res.content;
-
-          if (!this.params.skipMDFileCreation) {
-            const mdPath = `${res.path}.md`;
-            await this.params.storageHandler.put(mdPath, res.content);
-            this.logger.log(`MD file created: ${mdPath}`);
-
+          if (entry.document) {
+            const res = await this.createMarkdown(entry, url);
             // eslint-disable-next-line no-param-reassign
-            entry.md = mdPath;
-          }
-
-          if (!this.params.skipDocxConversion) {
-            const docxPath = `${res.path}.docx`;
-            await this.convertToDocx(docxPath, res.content);
+            entry.source = url;
             // eslint-disable-next-line no-param-reassign
-            entry.docx = docxPath;
+            entry.path = res.path;
+            // eslint-disable-next-line no-param-reassign
+            entry.markdown = res.content;
+
+            if (!this.params.skipMDFileCreation) {
+              const mdPath = `${res.path}.md`;
+              await this.params.storageHandler.put(mdPath, res.content);
+              this.logger.log(`MD file created: ${mdPath}`);
+
+              // eslint-disable-next-line no-param-reassign
+              entry.md = mdPath;
+            }
+
+            if (!this.params.skipDocxConversion) {
+              const docxPath = `${res.path}.docx`;
+              await this.convertToDocx(docxPath, res.content);
+              // eslint-disable-next-line no-param-reassign
+              entry.docx = docxPath;
+            }
           }
 
           results.push(entry);

--- a/test/importers/HTML2x.spec.js
+++ b/test/importers/HTML2x.spec.js
@@ -230,6 +230,35 @@ describe('html2md tests', () => {
     strictEqual(out2.report.somethingElse, 'something else');
   });
 
+  it('html2md allows no element to be provided when using transform', async () => {
+    const out = await html2md('https://www.sample.com/page.html', '<html><body><h1>Hello World</h1></body></html>', {
+      transform: () => [{
+        path: '/my-custom-path-p1',
+        report: {
+          custom: 'A custom property',
+          customArray: ['a', 'b', 'c'],
+          customObject: {
+            a: 1,
+            b: true,
+            c: {
+              d: 'e',
+            },
+          },
+        },
+      }],
+    });
+
+    // if no element provided, no creation of html, md or docx
+    strictEqual(out.html, undefined);
+    strictEqual(out.md, undefined);
+    strictEqual(out.docx, undefined);
+    strictEqual(out.path, '/my-custom-path-p1');
+    ok(out.report);
+    strictEqual(out.report.custom, 'A custom property');
+    deepStrictEqual(out.report.customArray, ['a', 'b', 'c']);
+    deepStrictEqual(out.report.customObject, { a: 1, b: true, c: { d: 'e' } });
+  });
+
   it('html2md does not crash if transform returns null', async () => {
     const out = await html2md('https://www.sample.com/page.html', '<html><body><h1>Hello World</h1></body></html>', {
       transform: () => null,


### PR DESCRIPTION
Allow the object returned by the `transform` method to contain no `element`. With the `report` property only (`path` is mandatory), `transform` can now return something like:

```
{ 
  path: 'path to be imported',
  report: {
    prop1: '...',
    prop2: '...',
    ...
  }
}
```

which could then be used to extract "data" of a page, not as md / docx content but as a JSON object.