### PR TITLE
chore: add test for empty / invalid tables

### DIFF
--- a/test/importers/PageImporter.spec.js
+++ b/test/importers/PageImporter.spec.js
@@ -147,7 +147,7 @@ describe('PageImporter tests - fixtures', () => {
 
     const md = await storageHandler.get(results[0].md);
     const expectedMD = await fs.readFile(path.resolve(__dirname, 'fixtures', `${feature}.spec.md`), 'utf-8');
-    strictEqual(md.trim(), expectedMD.trim(), 'inported md is expected one');
+    strictEqual(md.trim(), expectedMD.trim(), 'imported md is expected one');
   };
 
   it('import - tables', async () => {

--- a/test/importers/fixtures/table.spec.html
+++ b/test/importers/fixtures/table.spec.html
@@ -27,5 +27,7 @@
         </td>
       </tr>
     </table>
+    <table></table>
+    <table><tr></tr><tr></tr></table>
   </body>
 </html>


### PR DESCRIPTION
Issue https://github.com/adobe/helix-importer-ui/issues/80 has been addressed via https://github.com/adobe/mdast-util-gridtables/issues/22
Adding corresponding tests to avoid regressions