### PR TITLE
fix: support <s> tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "node-fetch": "3.3.0",
     "rehype-parse": "8.0.4",
     "rehype-remark": "github:adobe-rnd/rehype-remark#45735e80a3d3c805d3c4211ae035f718ddd10bcb",
+    "remark-gfm": "3.0.1",
     "remark-stringify": "10.0.2",
     "unified": "10.1.2"
   }

--- a/src/importer/PageImporter.js
+++ b/src/importer/PageImporter.js
@@ -19,11 +19,10 @@ import { unified } from 'unified';
 import parse from 'rehype-parse';
 import rehype2remark from 'rehype-remark';
 import stringify from 'remark-stringify';
-import remarkGfm from 'remark-gfm';
 import fs from 'fs-extra';
 import { md2docx } from '@adobe/helix-md2docx';
 import remarkGridTable from '@adobe/remark-gridtables';
-import { imageReferences } from '@adobe/helix-markdown-support';
+import { imageReferences, remarkGfmNoLink } from '@adobe/helix-markdown-support';
 import gridtableHandlers from './hast-to-mdast-gridtable-handlers.js';
 import Utils from '../utils/Utils.js';
 import DOMUtils from '../utils/DOMUtils.js';
@@ -85,7 +84,7 @@ export default class PageImporter {
       })
       .use(remarkImageReferences)
       .use(remarkGridTable)
-      .use(remarkGfm)
+      .use(remarkGfmNoLink)
       .use(stringify, {
         bullet: '-',
         fence: '`',

--- a/src/importer/PageImporter.js
+++ b/src/importer/PageImporter.js
@@ -19,6 +19,7 @@ import { unified } from 'unified';
 import parse from 'rehype-parse';
 import rehype2remark from 'rehype-remark';
 import stringify from 'remark-stringify';
+import remarkGfm from 'remark-gfm';
 import fs from 'fs-extra';
 import { md2docx } from '@adobe/helix-md2docx';
 import remarkGridTable from '@adobe/remark-gridtables';
@@ -84,6 +85,7 @@ export default class PageImporter {
       })
       .use(remarkImageReferences)
       .use(remarkGridTable)
+      .use(remarkGfm)
       .use(stringify, {
         bullet: '-',
         fence: '`',

--- a/test/importers/PageImporter.spec.js
+++ b/test/importers/PageImporter.spec.js
@@ -178,7 +178,7 @@ describe('PageImporter tests - fixtures', () => {
     await featureTest('space');
   });
 
-  it('import - strikethrough', async () => {
+  it('import - strikethroughs', async () => {
     await featureTest('s');
   });
 });

--- a/test/importers/PageImporter.spec.js
+++ b/test/importers/PageImporter.spec.js
@@ -177,4 +177,8 @@ describe('PageImporter tests - fixtures', () => {
   it('import - spaces', async () => {
     await featureTest('space');
   });
+
+  it('import - strikethrough', async () => {
+    await featureTest('s');
+  });
 });

--- a/test/importers/fixtures/s.spec.html
+++ b/test/importers/fixtures/s.spec.html
@@ -1,7 +1,9 @@
 <html>
   <body>
-    <h1>strike sample</h1>
-    <s>strike 1</s>
+    <h1>strikethrough sample</h1>
+    <p><s>strikethrough 1</s></p>
+    <p>removed <del>strikethrough 2</del> but added <ins>strikethrough 3</ins></p>
+    <p></p>
     <p>
       <b>
         <s><span>US$84.99/mo</span></s>

--- a/test/importers/fixtures/s.spec.html
+++ b/test/importers/fixtures/s.spec.html
@@ -1,0 +1,12 @@
+<html>
+  <body>
+    <h1>strike sample</h1>
+    <s>strike 1</s>
+    <p>
+      <b>
+        <s><span>US$84.99/mo</span></s>
+        <span>US$59.99/mo</span>&nbsp;per license
+      </b>
+    </p>
+  </body>
+</html>

--- a/test/importers/fixtures/s.spec.html
+++ b/test/importers/fixtures/s.spec.html
@@ -2,7 +2,7 @@
   <body>
     <h1>strikethrough sample</h1>
     <p><s>strikethrough 1</s></p>
-    <p>removed <del>strikethrough 2</del> but added <ins>strikethrough 3</ins></p>
+    <p>removed <del>strikethrough 2</del> but added <ins>insert 3</ins></p>
     <p></p>
     <p>
       <b>

--- a/test/importers/fixtures/s.spec.md
+++ b/test/importers/fixtures/s.spec.md
@@ -2,6 +2,6 @@
 
 ~~strikethrough 1~~
 
-removed ~~strikethrough 2~~ but added strikethrough 3
+removed ~~strikethrough 2~~ but added insert 3
 
 **~~US$84.99/mo~~ US$59.99/mo per license**

--- a/test/importers/fixtures/s.spec.md
+++ b/test/importers/fixtures/s.spec.md
@@ -1,0 +1,5 @@
+# strike sample
+
+~~strike 1~~
+
+**~~US$84.99/mo~~ US$59.99/mo per license**

--- a/test/importers/fixtures/s.spec.md
+++ b/test/importers/fixtures/s.spec.md
@@ -1,5 +1,7 @@
-# strike sample
+# strikethrough sample
 
-~~strike 1~~
+~~strikethrough 1~~
+
+removed ~~strikethrough 2~~ but added strikethrough 3
 
 **~~US$84.99/mo~~ US$59.99/mo per license**


### PR DESCRIPTION
Fix #75 

Only one test is failing, waiting for tobi to extract https://github.com/adobe/helix-html-pipeline/blob/main/src/utils/remark-gfm-nolink.js in the helix-markdown-support library.