### PR TITLE
fix: catch invalid link decoding

### DIFF
--- a/src/importer/PageImporter.js
+++ b/src/importer/PageImporter.js
@@ -116,8 +116,8 @@ export default class PageImporter {
     const as = document.querySelectorAll('a');
     as.forEach((a) => {
       const { href } = a;
-      if ((href && href !== '' && contents.indexOf(href) !== -1) || contents.indexOf(decodeURI(href)) !== -1) {
-        try {
+      try {
+        if ((href && href !== '' && contents.indexOf(href) !== -1) || contents.indexOf(decodeURI(href)) !== -1) {
           const u = new URL(href, url);
           const ext = path.extname(u.href);
           if (ext === '.mp4') {
@@ -127,9 +127,9 @@ export default class PageImporter {
               append: '#image.mp4',
             });
           }
-        } catch (error) {
-          this.logger.warn(`Invalid link in the page: ${href}`, error);
         }
+      } catch (error) {
+        this.logger.warn(`Invalid link in the page - ${href}`, error);
       }
     });
 

--- a/test/importers/fixtures/link.spec.html
+++ b/test/importers/fixtures/link.spec.html
@@ -4,5 +4,6 @@
     <p><a href="http://wwww.sample.com/a">Link on a single online</a></p>
     <a href="http://wwww.sample.com/b">Link without p</a>
     <p>http://wwww.sample.com/c</p>
+    <a href="https://www.sample.com/app/answers/detail/a_id/17414//~/axon%E2%84%A2-pclamp%E2%AE-and-digidata%E2%84%A2%3A-operating-system-compatibility#:\\~:text=Digidata%201440%2C%201550%2C%201550A%2C,supported%20up%20to%20pCLAMP%2010.3.&text=MiniDigi%201B%20is%20required%20for%20use%20under%2064%2Dbit%20Operating%20Systems.&text=pCLAMP%209%20software%20is%20not,or%2064%2Dbit%20versions">Weird link</a>
   </body>
 </html>

--- a/test/importers/fixtures/link.spec.md
+++ b/test/importers/fixtures/link.spec.md
@@ -5,3 +5,5 @@
 [Link without p](http://wwww.sample.com/b)
 
 http://wwww.sample.com/c
+
+[Weird link](https://www.sample.com/app/answers/detail/a_id/17414//\~/axon%E2%84%A2-pclamp%E2%AE-and-digidata%E2%84%A2%3A-operating-system-compatibility#:\\\\\~:text=Digidata%201440%2C%201550%2C%201550A%2C,supported%20up%20to%20pCLAMP%2010.3.\&text=MiniDigi%201B%20is%20required%20for%20use%20under%2064%2Dbit%20Operating%20Systems.\&text=pCLAMP%209%20software%20is%20not,or%2064%2Dbit%20versions)


### PR DESCRIPTION
Some weird links might crash the import process because they cannot be uri decoded...
