### PR TITLE
fix: replace &nbsp; with space

### DIFF
--- a/src/utils/DOMUtils.js
+++ b/src/utils/DOMUtils.js
@@ -103,10 +103,12 @@ export default class DOMUtils {
         (tag.textContent === ''
           || tag.textContent === ' '
           || tag.textContent === '&nbsp;'
-          || tag.textContent.charCodeAt(0) === 160)
+          || (tag.textContent.charCodeAt(0) === 160 && tag.textContent.length === 1))
         && !tag.querySelector(DOMUtils.EMPTY_TAGS_TO_PRESERVE.join(','))
       ) {
         tag.remove();
+      } else {
+        tag.innerHTML = tag.innerHTML.replace(/&nbsp;/gm, ' ');
       }
     }
   }

--- a/test/importers/fixtures/space.spec.html
+++ b/test/importers/fixtures/space.spec.html
@@ -4,10 +4,11 @@
     <p>A simple paragraph</p>
     <p>A paragraph with a br inside.<br> This should be next line.</p>
     <p>A paragraph with a br at the end.<br></p>
+    <p>A paragraph with a br at the end and &amp;nbsp; "&nbsp;".<br> &nbsp;</p>
     <p>A paragraph followed by a br</p>
     <br>
     <p>A paragraph after the br</p>
-    &nbsp;
+    <p>&nbsp;</p>
     <p>A paragraph after the nbsp;</p>
   </body>
 </html>

--- a/test/importers/fixtures/space.spec.md
+++ b/test/importers/fixtures/space.spec.md
@@ -7,13 +7,13 @@ This should be next line.
 
 A paragraph with a br at the end.
 
+A paragraph with a br at the end and \&nbsp; " ".
+
 A paragraph followed by a br
 
 \
 
 
 A paragraph after the br
-
- 
 
 A paragraph after the nbsp;

--- a/test/utils/DOMUtils.spec.js
+++ b/test/utils/DOMUtils.spec.js
@@ -95,6 +95,11 @@ describe('DOMUtils#reviewParagraphs tests', () => {
     test('<p><video width="320" height="240" controls=""><source src="movie.mp4" type="video/mp4"></video></p>', '<p><video width="320" height="240" controls=""><source src="movie.mp4" type="video/mp4"></video></p>');
     test('<p><iframe src="www.iframe.com"></iframe></p>', '<p><iframe src="www.iframe.com"></iframe></p>');
   });
+
+  it('reviewParagraphs replaces &nbsp; with spaces', () => {
+    test('<p>usefull with space&nbsp;</p>', '<p>usefull with space </p>');
+    test('<p>&nbsp;more&nbsp;spaces&nbsp;<br> &nbsp;</p>', '<p> more spaces <br>  </p>');
+  });
 });
 
 describe('DOMUtils#reviewHeadings tests', () => {


### PR DESCRIPTION
Fix https://github.com/adobe/helix-importer-ui/issues/173

I could not identify how to handle the `&nbsp;` properly: it leads to a trailing slash. The easiest solution is to replace it with a space character which is then correctly handled.

@tripodsan WDYT ?