### PR TITLE
fix: properly escape tilde

### DIFF
--- a/src/importer/PageImporter.js
+++ b/src/importer/PageImporter.js
@@ -99,7 +99,8 @@ export default class PageImporter {
         ruleSpaces: false,
       });
 
-    const file = await processor.process(resource.document.innerHTML);
+    const html = resource.document.innerHTML;
+    const file = await processor.process(html);
     let contents = String(file);
 
     // process image links
@@ -191,7 +192,6 @@ export default class PageImporter {
     this.cleanup(document);
     DOMUtils.reviewHeadings(document);
     DOMUtils.reviewParagraphs(document);
-    DOMUtils.escapeSpecialCharacters(document);
     [
       'b',
       'a',

--- a/src/utils/DOMUtils.js
+++ b/src/utils/DOMUtils.js
@@ -113,11 +113,6 @@ export default class DOMUtils {
     }
   }
 
-  static escapeSpecialCharacters(document) {
-    // eslint-disable-next-line no-param-reassign
-    document.body.innerHTML = document.body.innerHTML.replace(/~/gm, '\\~');
-  }
-
   static reviewHeadings(document) {
     const tags = [...document.querySelectorAll('h1, h2, h3, h4, h5, h6')];
     for (let i = tags.length - 1; i >= 0; i -= 1) {

--- a/src/utils/MDUtils.js
+++ b/src/utils/MDUtils.js
@@ -20,7 +20,7 @@ export default class MDUtils {
   };
 
   static cleanupMarkdown(md) {
-    let ret = md?.replace(/\\\\~/gm, '\\~');
+    let ret = md;
     if (ret) {
       for (let i = 0; i < 20; i += 1) {
         let x = `${i}`;

--- a/test/importers/PageImporter.spec.js
+++ b/test/importers/PageImporter.spec.js
@@ -178,6 +178,10 @@ describe('PageImporter tests - fixtures', () => {
     await featureTest('space');
   });
 
+  it('import - s', async () => {
+    await featureTest('s');
+  });
+
   it('import - sub and sup', async () => {
     await featureTest('subsup');
   });

--- a/test/importers/fixtures/link.spec.md
+++ b/test/importers/fixtures/link.spec.md
@@ -6,4 +6,4 @@
 
 http://wwww.sample.com/c
 
-[Weird link](https://www.sample.com/app/answers/detail/a_id/17414//\~/axon%E2%84%A2-pclamp%E2%AE-and-digidata%E2%84%A2%3A-operating-system-compatibility#:\\\\\~:text=Digidata%201440%2C%201550%2C%201550A%2C,supported%20up%20to%20pCLAMP%2010.3.\&text=MiniDigi%201B%20is%20required%20for%20use%20under%2064%2Dbit%20Operating%20Systems.\&text=pCLAMP%209%20software%20is%20not,or%2064%2Dbit%20versions)
+[Weird link](https://www.sample.com/app/answers/detail/a_id/17414//~/axon%E2%84%A2-pclamp%E2%AE-and-digidata%E2%84%A2%3A-operating-system-compatibility#:\\\\~:text=Digidata%201440%2C%201550%2C%201550A%2C,supported%20up%20to%20pCLAMP%2010.3.\&text=MiniDigi%201B%20is%20required%20for%20use%20under%2064%2Dbit%20Operating%20Systems.\&text=pCLAMP%209%20software%20is%20not,or%2064%2Dbit%20versions)

--- a/test/importers/fixtures/s.spec.html
+++ b/test/importers/fixtures/s.spec.html
@@ -10,5 +10,6 @@
         <span>US$59.99/mo</span>&nbsp;per license
       </b>
     </p>
+    <p>Text with ~tilde.</p>
   </body>
 </html>

--- a/test/importers/fixtures/s.spec.md
+++ b/test/importers/fixtures/s.spec.md
@@ -5,3 +5,5 @@
 removed ~~strikethrough 2~~ but added insert 3
 
 **~~US$84.99/mo~~ US$59.99/mo per license**
+
+Text with \~tilde.

--- a/test/utils/DOMUtils.spec.js
+++ b/test/utils/DOMUtils.spec.js
@@ -130,18 +130,6 @@ describe('DOMUtils#reviewHeadings tests', () => {
   });
 });
 
-describe('DOMUtils#escapeSpecialCharacters tests', () => {
-  const test = (input, expected) => {
-    const { document } = (new JSDOM(input)).window;
-    DOMUtils.escapeSpecialCharacters(document);
-    strictEqual(document.body.innerHTML, expected);
-  };
-
-  it('escapeSpecialCharacters escape tidles', () => {
-    test('<p>Paragraph with 2 tildes: 20~30 and 40~50</p>', '<p>Paragraph with 2 tildes: 20\\~30 and 40\\~50</p>');
-  });
-});
-
 describe('DOMUtils#remove tests', () => {
   const test = (input, selectors, expected) => {
     const { document } = (new JSDOM(input)).window;

--- a/test/utils/MDUtils.spec.js
+++ b/test/utils/MDUtils.spec.js
@@ -80,14 +80,6 @@ describe('MDUtils#cleanupMarkdown tests', () => {
     );
   });
 
-  it('MDUtils#cleanupMarkdown unescape tildes', () => {
-    strictEqual(
-      MDUtils.cleanupMarkdown('#A title\n~~Tilde can be an pb~~\n Especially \\\\~in the content'),
-      '#A title\n~~Tilde can be an pb~~\n Especially \\~in the content',
-      'unescape tildes',
-    );
-  });
-
   it('MDUtils#cleanupMarkdown replace weird spaces', () => {
     strictEqual(
       MDUtils.cleanupMarkdown('#A title\nReplaces the weird spaces characters: "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u0009\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019"'),


### PR DESCRIPTION
fixes #189

with the recent markdown libraries, the tilde doesn't need special treatment and is always escaped and parsed correctly.