### PR TITLE
fix: cleanup mdast tree before writing as md

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/helix-importer",
-  "version": "2.9.27",
+  "version": "2.9.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/helix-importer",
-      "version": "2.9.27",
+      "version": "2.9.28",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-markdown-support": "6.3.1",
@@ -38,7 +38,9 @@
         "mocha": "10.2.0",
         "mocha-multi-reporters": "1.5.1",
         "mock-fs": "5.2.0",
-        "semantic-release": "21.1.1"
+        "remark-parse": "10.0.2",
+        "semantic-release": "21.1.1",
+        "unist-util-inspect": "8.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -16514,6 +16516,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-util-inspect": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-inspect/-/unist-util-inspect-8.0.0.tgz",
+      "integrity": "sha512-/3Wn/wU6/H6UEo4FoYUeo8KUePN8ERiZpQYFWYoihOsr1DoDuv80PeB0hobVZyYSvALa2e556bG1A1/AbwU4yg==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-inspect/node_modules/@types/unist": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
+      "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w==",
+      "dev": true
+    },
     "node_modules/unist-util-is": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.0.tgz",
@@ -29066,6 +29087,23 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.1.tgz",
       "integrity": "sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A=="
+    },
+    "unist-util-inspect": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-inspect/-/unist-util-inspect-8.0.0.tgz",
+      "integrity": "sha512-/3Wn/wU6/H6UEo4FoYUeo8KUePN8ERiZpQYFWYoihOsr1DoDuv80PeB0hobVZyYSvALa2e556bG1A1/AbwU4yg==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^3.0.0"
+      },
+      "dependencies": {
+        "@types/unist": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
+          "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w==",
+          "dev": true
+        }
+      }
     },
     "unist-util-is": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "mocha": "10.2.0",
     "mocha-multi-reporters": "1.5.1",
     "mock-fs": "5.2.0",
-    "semantic-release": "21.1.1"
+    "remark-parse": "10.0.2",
+    "semantic-release": "21.1.1",
+    "unist-util-inspect": "8.0.0"
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/src/importer/mdast-to-md-format-plugin.js
+++ b/src/importer/mdast-to-md-format-plugin.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/**
+ * Renders special html only format.
+ */
+function format(tagName) {
+  const tagOpen = `<${tagName}>`;
+  const tagClose = `</${tagName}>`;
+
+  /**
+   * @param {Node} node
+   * @param {Parents | undefined} _
+   * @param {State} state
+   * @param {Info} info
+   * @returns {string}
+   */
+  return (node, _, state, info) => {
+    const exit = state.enter('html');
+    const tracker = state.createTracker(info);
+    let value = tracker.move(tagOpen);
+    value += tracker.move(
+      state.containerPhrasing(node, {
+        before: value,
+        after: tagOpen,
+        ...tracker.current(),
+      }),
+    );
+    value += tracker.move(tagClose);
+    exit();
+    return value;
+  };
+}
+
+function toMarkdown() {
+  return {
+    handlers: {
+      subscript: format('sub'),
+      superscript: format('sup'),
+      underline: format('u'),
+    },
+  };
+}
+
+export default function formatPlugin(options) {
+  const data = this.data();
+
+  function add(field, value) {
+    /* c8 ignore next 2 */
+    if (data[field]) {
+      data[field].push(value);
+    } else {
+      data[field] = [value];
+    }
+  }
+
+  // add('micromarkExtensions', syntax(options));
+  // add('fromMarkdownExtensions', fromMarkdown(options));
+  add('toMarkdownExtensions', toMarkdown(options));
+}

--- a/test/importers/PageImporter.spec.js
+++ b/test/importers/PageImporter.spec.js
@@ -21,6 +21,11 @@ import { dirname } from 'dirname-filename-esm';
 
 import { docx2md } from '@adobe/helix-docx2md';
 
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkGridTable from '@adobe/remark-gridtables';
+// eslint-disable-next-line no-unused-vars
+import { inspect, inspectNoColor } from 'unist-util-inspect';
 import PageImporter from '../../src/importer/PageImporter.js';
 import PageImporterResource from '../../src/importer/PageImporterResource.js';
 import MemoryHandler from '../../src/storage/MemoryHandler.js';
@@ -148,6 +153,22 @@ describe('PageImporter tests - fixtures', () => {
     const md = await storageHandler.get(results[0].md);
     const expectedMD = await fs.readFile(path.resolve(__dirname, 'fixtures', `${feature}.spec.md`), 'utf-8');
     strictEqual(md.trim(), expectedMD.trim(), 'imported md is expected one');
+
+    // parse md to verify mdast
+    const mdast = unified()
+      .use(remarkParse)
+      .use(remarkGridTable)
+      .use()
+      .parse(md);
+
+    // process.stdout.write(inspect(mdast, { showPositions: false }));
+    // process.stdout.write('\n');
+
+    if (await fs.pathExistsSync(path.resolve(__dirname, 'fixtures', `${feature}.spec.mdast`))) {
+      const actualMdast = inspectNoColor(mdast, { showPositions: false });
+      const expectedMdast = await fs.readFile(path.resolve(__dirname, 'fixtures', `${feature}.spec.mdast`), 'utf-8');
+      strictEqual(actualMdast.trim(), expectedMdast.trim(), 'imported mdast is expected one');
+    }
   };
 
   it('import - tables', async () => {

--- a/test/importers/fixtures/em.spec.html
+++ b/test/importers/fixtures/em.spec.html
@@ -4,5 +4,6 @@
     <p><strong><em>&nbsp;</em></strong></p><p>usefull</p>
     <p><strong><em>emphasis</em></strong><strong><em> space </em></strong><strong><em>another emphasis</em></strong> <strong><em>last emphasis</em></strong></p>
     <p><a href="https://www.sample.com">linkcontent</a><i>. </i></p>
+    <p><strong><em>Side shuffle </em></strong><em>– </em>Quadriceps, glutes, hamstrings, calves</p>
   </body>
 </html>

--- a/test/importers/fixtures/em.spec.md
+++ b/test/importers/fixtures/em.spec.md
@@ -2,6 +2,8 @@
 
 usefull
 
-***emphasis* *space* *another emphasis* *last emphasis***
+**_emphasis_ _space_ _another emphasis_ _last emphasis_**
 
 [linkcontent](https://www.sample.com).
+
+**_Side shuffle_** _–_ Quadriceps, glutes, hamstrings, calves

--- a/test/importers/fixtures/em.spec.mdast
+++ b/test/importers/fixtures/em.spec.mdast
@@ -1,0 +1,33 @@
+root[5]
+├─0 heading[1]
+│   │ depth: 1
+│   └─0 text "EM sample"
+├─1 paragraph[1]
+│   └─0 text "usefull"
+├─2 paragraph[1]
+│   └─0 strong[7]
+│       ├─0 emphasis[1]
+│       │   └─0 text "emphasis"
+│       ├─1 text " "
+│       ├─2 emphasis[1]
+│       │   └─0 text "space"
+│       ├─3 text " "
+│       ├─4 emphasis[1]
+│       │   └─0 text "another emphasis"
+│       ├─5 text " "
+│       └─6 emphasis[1]
+│           └─0 text "last emphasis"
+├─3 paragraph[2]
+│   ├─0 link[1]
+│   │   │ title: null
+│   │   │ url: "https://www.sample.com"
+│   │   └─0 text "linkcontent"
+│   └─1 text "."
+└─4 paragraph[4]
+    ├─0 strong[1]
+    │   └─0 emphasis[1]
+    │       └─0 text "Side shuffle"
+    ├─1 text " "
+    ├─2 emphasis[1]
+    │   └─0 text "–"
+    └─3 text " Quadriceps, glutes, hamstrings, calves"

--- a/test/importers/fixtures/space.spec.md
+++ b/test/importers/fixtures/space.spec.md
@@ -11,9 +11,6 @@ A paragraph with a br at the end and \&nbsp; " ".
 
 A paragraph followed by a br
 
-\
-
-
 A paragraph after the br
 
 A paragraph after the nbsp;

--- a/test/importers/fixtures/u.spec.md
+++ b/test/importers/fixtures/u.spec.md
@@ -8,20 +8,14 @@ Some normal text with random <u>underline</u> or <u>span with underline</u> or <
 
 **<u>Underline 3</u>**
 
--   <u>
-    li underline 1
-    </u>
--   <u>
-    li underline 2
-    </u>
+-   <u>li underline 1</u>
+-   <u>li underline 2</u>
     also may have text here
--   <u>
-    li underline 3
-    </u>
+-   <u>li underline 3</u>
 
 [Unlined link](https:/www.sample.com/a) or [<u>Linked underline</u>](https:/www.sample.com/b) ?
 
-<u>**Some underline and strong text**</u>
+**<u>Some underline and strong text</u>**
 
 [U and A are not friends](https://www.austinparks.org/)[Boys & Girls Clubs of the Austin Area](http://www.bgcaustin.org/)[The First Tee of Greater Austin](http://www.thefirstteeaustin.org/club/scripts/public/public.asp)
 

--- a/test/importers/fixtures/u.spec.mdast
+++ b/test/importers/fixtures/u.spec.mdast
@@ -1,0 +1,102 @@
+root[10]
+├─0 heading[1]
+│   │ depth: 1
+│   └─0 text "Underline combo sample"
+├─1 paragraph[3]
+│   ├─0 html "<u>"
+│   ├─1 text "Underline 1"
+│   └─2 html "</u>"
+├─2 paragraph[13]
+│   ├─0  text "Some normal text with random "
+│   ├─1  html "<u>"
+│   ├─2  text "underline"
+│   ├─3  html "</u>"
+│   ├─4  text " or "
+│   ├─5  html "<u>"
+│   ├─6  text "span with underline"
+│   ├─7  html "</u>"
+│   ├─8  text " or "
+│   ├─9  html "<u>"
+│   ├─10 text "underline with span"
+│   ├─11 html "</u>"
+│   └─12 text "..."
+├─3 paragraph[1]
+│   └─0 strong[3]
+│       ├─0 html "<u>"
+│       ├─1 text "Underline 2"
+│       └─2 html "</u>"
+├─4 paragraph[1]
+│   └─0 strong[3]
+│       ├─0 html "<u>"
+│       ├─1 text "Underline 3"
+│       └─2 html "</u>"
+├─5 list[3]
+│   │ ordered: false
+│   │ start: null
+│   │ spread: false
+│   ├─0 listItem[1]
+│   │   │ spread: false
+│   │   │ checked: null
+│   │   └─0 paragraph[3]
+│   │       ├─0 html "<u>"
+│   │       ├─1 text "li underline 1"
+│   │       └─2 html "</u>"
+│   ├─1 listItem[1]
+│   │   │ spread: false
+│   │   │ checked: null
+│   │   └─0 paragraph[4]
+│   │       ├─0 html "<u>"
+│   │       ├─1 text "li underline 2"
+│   │       ├─2 html "</u>"
+│   │       └─3 text "\nalso may have text here"
+│   └─2 listItem[1]
+│       │ spread: false
+│       │ checked: null
+│       └─0 paragraph[3]
+│           ├─0 html "<u>"
+│           ├─1 text "li underline 3"
+│           └─2 html "</u>"
+├─6 paragraph[4]
+│   ├─0 link[1]
+│   │   │ title: null
+│   │   │ url: "https:/www.sample.com/a"
+│   │   └─0 text "Unlined link"
+│   ├─1 text " or "
+│   ├─2 link[3]
+│   │   │ title: null
+│   │   │ url: "https:/www.sample.com/b"
+│   │   ├─0 html "<u>"
+│   │   ├─1 text "Linked underline"
+│   │   └─2 html "</u>"
+│   └─3 text " ?"
+├─7 paragraph[1]
+│   └─0 strong[3]
+│       ├─0 html "<u>"
+│       ├─1 text "Some underline and strong text"
+│       └─2 html "</u>"
+├─8 paragraph[3]
+│   ├─0 link[1]
+│   │   │ title: null
+│   │   │ url: "https://www.austinparks.org/"
+│   │   └─0 text "U and A are not friends"
+│   ├─1 link[1]
+│   │   │ title: null
+│   │   │ url: "http://www.bgcaustin.org/"
+│   │   └─0 text "Boys & Girls Clubs of the Austin Area"
+│   └─2 link[1]
+│       │ title: null
+│       │ url: "http://www.thefirstteeaustin.org/club/scripts/public/public.asp"
+│       └─0 text "The First Tee of Greater Austin"
+└─9 paragraph[3]
+    ├─0 link[1]
+    │   │ title: null
+    │   │ url: "https://www.austinparks.org/"
+    │   └─0 text "U and A are not friends"
+    ├─1 link[1]
+    │   │ title: null
+    │   │ url: "http://www.bgcaustin.org/"
+    │   └─0 text "Boys & Girls Clubs of the Austin Area"
+    └─2 link[1]
+        │ title: null
+        │ url: "http://www.thefirstteeaustin.org/club/scripts/public/public.asp"
+        └─0 text "The First Tee of Greater Austin"


### PR DESCRIPTION
splits the html->md conversion into 3 parts: html->hast, hast->mdast, mdast->md
this has the advantage that the mdast can be cleaned up in order to produce neat md. and allows for future optimization where the docx generation can happen directly on the mdast.

- fixes #217
- fixes #214
- fixes #166
- fixes #213
