### PR TITLE
fix: improve comments cleanup logic

### DIFF
--- a/src/utils/DOMUtils.js
+++ b/src/utils/DOMUtils.js
@@ -139,7 +139,8 @@ export default class DOMUtils {
     // eslint-disable-next-line no-param-reassign
     document.body.innerHTML = document.body.innerHTML
       // remove html comments
-      .replace(/<!--(?!>)[\S\s]*?-->/gm, '');
+      .replace(/><!--(?!>)[\S\s]*?-->/gm, '>')
+      .replace(/\n<!--(?!>)[\S\s]*?-->/gm, '\n');
   }
 
   static removeSpans(document) {

--- a/test/utils/DOMUtils.spec.js
+++ b/test/utils/DOMUtils.spec.js
@@ -182,6 +182,8 @@ describe('DOMUtils#removeCommments tests', () => {
     test('<p><!-- useless comment \n multiline --></p>', '<p></p>');
     test('<p><!-- useless comment \n multiline \n multiline --></p>', '<p></p>');
     test('<!-- useless comment --><p>The content stays</p><!-- another useless comment with \n line break -->', '<p>The content stays</p>');
+    test('<p>This is a paragraph.</p>\n\x3C!--\n<p>Look at this cool image:</p>\n<img border="0" src="pic_trulli.jpg" alt="Trulli">\n-->\n<p>This is a paragraph too.</p>\x3C!-- same line -->\n\x3C!-- single line -->', '<p>This is a paragraph.</p>\n\n<p>This is a paragraph too.</p>\n');
+    test('<div some-crazy-attribute="" <!--=""><!-- useless comment --></div>', '<div some-crazy-attribute="" <!--=""></div>');
   });
 });
 


### PR DESCRIPTION
While importing https://news.sap.com/2023/03/sap-cx-intelligent-industry-tailored-solutions/, @mhaack found a weird behaviour: content gets stripped out.

Root cause: page contains a `ds-contextual-navigation` web component with attribute `last-visited-country="" <!--=""`. Of course attribute value breaks the comments cleanup logic (string regex based).

PR improves the regex and cleanup logic, even though I am not sure removing comments still matter now we are using a DOM element everywhere.